### PR TITLE
feat: upgrade spring ai dependency

### DIFF
--- a/jchunk-semantic/src/main/java/jchunk/chunker/semantic/Sentence.java
+++ b/jchunk-semantic/src/main/java/jchunk/chunker/semantic/Sentence.java
@@ -15,7 +15,7 @@ public class Sentence {
 
 	private String combined;
 
-	private List<Double> embedding;
+	private float[] embedding;
 
 	public Integer getIndex() {
 		return index;
@@ -41,11 +41,11 @@ public class Sentence {
 		this.combined = combined;
 	}
 
-	public List<Double> getEmbedding() {
+	public float[] getEmbedding() {
 		return embedding;
 	}
 
-	public void setEmbedding(List<Double> embedding) {
+	public void setEmbedding(float[] embedding) {
 		this.embedding = embedding;
 	}
 
@@ -72,7 +72,7 @@ public class Sentence {
 			return this;
 		}
 
-		public Builder embedding(List<Double> embedding) {
+		public Builder embedding(float[] embedding) {
 			this.sentence.setEmbedding(embedding);
 			return this;
 		}

--- a/jchunk-semantic/src/main/java/jchunk/chunker/semantic/Utils.java
+++ b/jchunk-semantic/src/main/java/jchunk/chunker/semantic/Utils.java
@@ -95,7 +95,7 @@ public class Utils {
 
 		List<String> sentencesText = sentences.stream().map(Sentence::getContent).toList();
 
-		List<List<Double>> embeddings = embeddingModel.embed(sentencesText);
+		List<float[]> embeddings = embeddingModel.embed(sentencesText);
 
 		return IntStream.range(0, sentences.size()).mapToObj(i -> {
 			Sentence sentence = sentences.get(i);
@@ -110,13 +110,13 @@ public class Utils {
 	 * @param sentence2 the second sentence embedding
 	 * @return the cosine similarity between the sentences
 	 */
-	public static Double cosineSimilarity(List<Double> sentence1, List<Double> sentence2) {
+	public static Double cosineSimilarity(float[] sentence1, float[] sentence2) {
 		assert sentence1 != null : "The first sentence embedding cannot be null";
 		assert sentence2 != null : "The second sentence embedding cannot be null";
-		assert sentence1.size() == sentence2.size() : "The sentence embeddings must have the same size";
+		assert sentence1.length == sentence2.length : "The sentence embeddings must have the same size";
 
-		INDArray arrayA = Nd4j.create(sentence1.stream().mapToDouble(Double::doubleValue).toArray());
-		INDArray arrayB = Nd4j.create(sentence2.stream().mapToDouble(Double::doubleValue).toArray());
+		INDArray arrayA = Nd4j.create(sentence1);
+		INDArray arrayB = Nd4j.create(sentence2);
 
 		arrayA = arrayA.div(arrayA.norm2Number());
 		arrayB = arrayB.div(arrayB.norm2Number());

--- a/jchunk-semantic/src/test/java/jchunk/chunker/semantic/SemanticChunkerUtilsTest.java
+++ b/jchunk-semantic/src/test/java/jchunk/chunker/semantic/SemanticChunkerUtilsTest.java
@@ -8,9 +8,12 @@ import org.springframework.ai.embedding.EmbeddingModel;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 class SemanticChunkerUtilsTest {
+
+	final static double MARGIN = 0.0001f;
 
 	final EmbeddingModel embeddingModel;
 
@@ -144,14 +147,17 @@ class SemanticChunkerUtilsTest {
 	@Test
 	void embedSentencesTest() {
 		Mockito.when(embeddingModel.embed(Mockito.anyList()))
-			.thenReturn(List.of(List.of(1.0, 2.0, 3.0), List.of(4.0, 5.0, 6.0)));
+			.thenReturn(List.of(new float[] { 1.0f, 2.0f, 3.0f }, new float[] { 4.0f, 5.0f, 6.0f }));
 
 		List<Sentence> sentences = List.of(Sentence.builder().combined("This is a test sentence.").build(),
 				Sentence.builder().combined("How are u?").build());
 
 		List<Sentence> expectedResult = List.of(
-				Sentence.builder().combined("This is a test sentence.").embedding(List.of(1.0, 2.0, 3.0)).build(),
-				Sentence.builder().combined("How are u?").embedding(List.of(4.0, 5.0, 6.0)).build());
+				Sentence.builder()
+					.combined("This is a test sentence.")
+					.embedding(new float[] { 1.0f, 2.0f, 3.0f })
+					.build(),
+				Sentence.builder().combined("How are u?").embedding(new float[] { 4.0f, 5.0f, 6.0f }).build());
 
 		List<Sentence> result = Utils.embedSentences(embeddingModel, sentences);
 
@@ -166,18 +172,18 @@ class SemanticChunkerUtilsTest {
 
 	@Test
 	void testIdenticalVectors() {
-		List<Double> embedding1 = List.of(1.0, 2.0, 3.0);
-		List<Double> embedding2 = List.of(1.0, 2.0, 3.0);
+		float[] embedding1 = new float[] { 1.0f, 2.0f, 3.0f };
+		float[] embedding2 = new float[] { 1.0f, 2.0f, 3.0f };
 
 		double result = Utils.cosineSimilarity(embedding1, embedding2);
 
-		assertThat(result).isEqualTo(1.0);
+		assertThat(result).isCloseTo(1.0, within(MARGIN));
 	}
 
 	@Test
 	void testOrthogonalVectors() {
-		List<Double> embedding1 = List.of(1.0, 0.0, 0.0);
-		List<Double> embedding2 = List.of(0.0, 1.0, 0.0);
+		float[] embedding1 = new float[] { 1.0f, 0.0f, 0.0f };
+		float[] embedding2 = new float[] { 0.0f, 1.0f, 0.0f };
 
 		double result = Utils.cosineSimilarity(embedding1, embedding2);
 
@@ -186,28 +192,28 @@ class SemanticChunkerUtilsTest {
 
 	@Test
 	void testOppositeVectors() {
-		List<Double> embedding1 = List.of(1.0, 2.0, 3.0);
-		List<Double> embedding2 = List.of(-1.0, -2.0, -3.0);
+		float[] embedding1 = new float[] { 1.0f, 2.0f, 3.0f };
+		float[] embedding2 = new float[] { -1.0f, -2.0f, -3.0f };
 
 		double result = Utils.cosineSimilarity(embedding1, embedding2);
 
-		assertThat(result).isEqualTo(-1.0);
+		assertThat(result).isCloseTo(-1.0, within(MARGIN));
 	}
 
 	@Test
 	void testDifferentMagnitudeVectors() {
-		List<Double> embedding1 = List.of(1.0, 2.0, 3.0);
-		List<Double> embedding2 = List.of(2.0, 4.0, 6.0);
+		float[] embedding1 = new float[] { 1.0f, 2.0f, 3.0f };
+		float[] embedding2 = new float[] { 2.0f, 4.0f, 6.0f };
 
 		double result = Utils.cosineSimilarity(embedding1, embedding2);
 
-		assertThat(result).isEqualTo(1.0);
+		assertThat(result).isCloseTo(1.0, within(MARGIN));
 	}
 
 	@Test
 	void testZeroVectors() {
-		List<Double> embedding1 = List.of(0.0, 0.0, 0.0);
-		List<Double> embedding2 = List.of(0.0, 0.0, 0.0);
+		float[] embedding1 = new float[] { 0.0f, 0.0f, 0.0f };
+		float[] embedding2 = new float[] { 0.0f, 0.0f, 0.0f };
 
 		double result = Utils.cosineSimilarity(embedding1, embedding2);
 

--- a/pom.xml
+++ b/pom.xml
@@ -48,13 +48,14 @@
 
 		<!-- production dependencies -->
 		<spring-boot.version>3.3.2</spring-boot.version>
-		<spring-ai.version>1.0.0-M1</spring-ai.version>
+		<spring-ai.version>1.0.0-M4</spring-ai.version>
 		<deeplearning4j.version>1.0.0-M2.1</deeplearning4j.version>
 
 		<!-- plugin versions -->
 		<spring-javaformat-maven-plugin.version>0.0.39</spring-javaformat-maven-plugin.version>
 		<maven-site-plugin.version>4.0.0-M13</maven-site-plugin.version>
 		<maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
+		<maven-release-plugin.version>3.0.0-M5</maven-release-plugin.version>
 		<jacoco.version>0.8.12</jacoco.version>
 		<scm.version>2.1.0</scm.version>
 	</properties>
@@ -144,7 +145,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-release-plugin</artifactId>
-				<version>3.0.0-M5</version>
+				<version>${maven-release-plugin.version}</version>
 				<configuration>
 					<tagNameFormat>v@{project.version}</tagNameFormat>
 					<autoVersionSubmodules>true</autoVersionSubmodules>


### PR DESCRIPTION
### Description
Upgrade SpringAi from M1 to M4

#### Breaking changes
Now SpringAI embeddings returns `float[]` instead of `List<Double>`