### PR TITLE
fix: replace is blank for is empty

### DIFF
--- a/jchunk-fixed/src/main/java/jchunk/chunker/fixed/Utils.java
+++ b/jchunk-fixed/src/main/java/jchunk/chunker/fixed/Utils.java
@@ -32,7 +32,7 @@ public class Utils {
 		String delimiter = config.getDelimiter();
 		Config.Delimiter keepDelimiter = config.getKeepDelimiter();
 
-		if (delimiter.isBlank()) {
+		if (delimiter.isEmpty()) {
 			return content.chars().mapToObj(c -> String.valueOf((char) c)).toList();
 		}
 

--- a/jchunk-fixed/src/test/java/jchunk/chunker/fixed/FixedChunkerIT.java
+++ b/jchunk-fixed/src/test/java/jchunk/chunker/fixed/FixedChunkerIT.java
@@ -25,7 +25,7 @@ class FixedChunkerIT {
 		List<Chunk> chunks = chunker.split(CONTENT);
 
 		assertThat(chunks).isNotNull().hasSize(1);
-
+		assertThat(chunks).containsExactlyElementsOf(expectedChunks);
 	}
 
 	@Test


### PR DESCRIPTION
### Description (must)

This PR introduces a hot fix,`isBlank` was producing an unexpected splitting with the default config.

### Changes (optional but helpful)

To fix it we have replaced `isBlank` for `isEmpty`.
